### PR TITLE
Reload automatically the graphs when a new stat is created

### DIFF
--- a/internal/server/start.go
+++ b/internal/server/start.go
@@ -50,16 +50,6 @@ func AsRoute(f any) any {
 	)
 }
 
-// AsHook annotates the given constructor to state that
-// it provides a hook to the "hooks" group.
-func AsHook(f any) any {
-	return fx.Annotate(
-		f,
-		fx.As(new(sqlstorage.SQLChangeHook)),
-		fx.ResultTags(`group:"hooks"`),
-	)
-}
-
 func start(ctx context.Context, cfg Config, invoke fx.Option) *fx.App {
 	app := fx.New(
 		fx.WithLogger(func(tools tools.Tools) fxevent.Logger { return logger.NewFxLogger(tools.Logger()) }),

--- a/internal/service/sysstats/init.go
+++ b/internal/service/sysstats/init.go
@@ -20,6 +20,7 @@ type Result struct {
 type Service interface {
 	GetLatest(ctx context.Context) (*Stats, error)
 	GetLast5mn(ctx context.Context) ([]Stats, error)
+	Watch(ctx context.Context) chan struct{}
 	fetchAndRegister(ctx context.Context) (*Stats, error)
 }
 

--- a/internal/service/sysstats/init.go
+++ b/internal/service/sysstats/init.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 
 	"github.com/Peltoche/zapette/internal/tools"
+	"github.com/Peltoche/zapette/internal/tools/sqlstorage"
 	"github.com/spf13/afero"
 	"go.uber.org/fx"
 )
@@ -12,6 +13,7 @@ import (
 type Result struct {
 	fx.Out
 	Service Service
+	Watcher sqlstorage.SQLChangeHook `group:"hooks"`
 	Cron    *SystatsCron
 }
 
@@ -27,6 +29,7 @@ func Init(db *sql.DB, fs afero.Fs, tools tools.Tools) Result {
 	svc := newService(storage, fs, tools)
 	return Result{
 		Service: svc,
+		Watcher: svc,
 		Cron:    newSystatCron(svc, tools),
 	}
 }

--- a/internal/tools/sqlstorage/driver.go
+++ b/internal/tools/sqlstorage/driver.go
@@ -18,14 +18,16 @@ func newDBWithHooks(dsn string, hookList *SQLChangeHookList, tools tools.Tools) 
 			}
 
 			conn.RegisterUpdateHook(func(op int, dbName string, tableName string, rowID int64) {
+				ctx := context.Background()
+
 				for _, hook := range hookList.GetHooks() {
-					err := hook.RunHook(tableName)
+					err := hook.RunSQLHook(ctx, tableName)
 					if err != nil {
-						tools.Logger().Error("RunHook error", slog.String("hook", hook.Name()), slog.String("error", err.Error()))
+						tools.Logger().Error("RunHook error", slog.String("hook", hook.SQLHookName()), slog.String("error", err.Error()))
 						return
 					}
 
-					tools.Logger().Debug("RunHook success", slog.String("hook", hook.Name()), slog.String("table", tableName))
+					tools.Logger().Debug("RunHook success", slog.String("hook", hook.SQLHookName()), slog.String("table", tableName))
 				}
 			})
 

--- a/internal/tools/sqlstorage/hooks.go
+++ b/internal/tools/sqlstorage/hooks.go
@@ -1,15 +1,15 @@
 package sqlstorage
 
 import (
+	"context"
 	"log/slog"
 
 	"github.com/Peltoche/zapette/internal/tools"
 )
 
 type SQLChangeHook interface {
-	Name() string
-	ShouldRunHook(table string) bool
-	RunHook(table string) error
+	SQLHookName() string
+	RunSQLHook(ctx context.Context, table string) error
 }
 
 type SQLChangeHookList struct {
@@ -32,6 +32,6 @@ func (l *SQLChangeHookList) AddHooks(hooks ...SQLChangeHook) {
 	l.inner = append(l.inner, hooks...)
 
 	for _, hook := range hooks {
-		l.logger.Debug("register SQL hook", slog.String("hook", hook.Name()))
+		l.logger.Debug("register SQL hook", slog.String("hook", hook.SQLHookName()))
 	}
 }

--- a/internal/web/handlers/sysstats/page_list.go
+++ b/internal/web/handlers/sysstats/page_list.go
@@ -1,6 +1,8 @@
 package sysstats
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
@@ -41,18 +43,75 @@ func (h *SysstatsPage) Register(r chi.Router, mids *router.Middlewares) {
 
 	r.Get("/", http.RedirectHandler("/web/sysstats", http.StatusFound).ServeHTTP)
 	r.Get("/web/sysstats", h.printListPage)
+	r.Get("/web/sysstats/data.json", h.servGraphData)
+	r.Get("/web/sysstats/sse", h.sse)
 }
 
-func (h *SysstatsPage) printListPage(w http.ResponseWriter, r *http.Request) {
-	user, _, abort := h.auth.GetUserAndSession(w, r, auth.AnyUser)
+func (h *SysstatsPage) servGraphData(w http.ResponseWriter, r *http.Request) {
+	_, _, abort := h.auth.GetUserAndSession(w, r, auth.AnyUser)
 	if abort {
 		return
 	}
 
-	stats, err := h.sysstats.GetLast5mn(r.Context())
+	graphData, err := h.getGraphData(r.Context())
 	if err != nil {
-		h.html.WriteHTMLErrorPage(w, r, fmt.Errorf("failed to get the latest 5mn stats: %w", err))
+		h.html.WriteHTMLErrorPage(w, r, err)
 		return
+	}
+
+	w.Header().Add("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(graphData)
+}
+
+func (h *SysstatsPage) printListPage(w http.ResponseWriter, r *http.Request) {
+	_, _, abort := h.auth.GetUserAndSession(w, r, auth.AnyUser)
+	if abort {
+		return
+	}
+
+	graphData, err := h.getGraphData(r.Context())
+	if err != nil {
+		h.html.WriteHTMLErrorPage(w, r, err)
+		return
+	}
+
+	h.html.WriteHTMLTemplate(w, r, http.StatusOK, &sysstatstmpl.SysstatsPageTmpl{
+		GraphData: graphData,
+	})
+}
+
+func (h *SysstatsPage) sse(w http.ResponseWriter, r *http.Request) {
+	// Set headers for SSE
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+
+	eventCh := h.sysstats.Watch(r.Context())
+
+	// Send data to the client
+	for range eventCh {
+		graphData, err := h.getGraphData(r.Context())
+		if err != nil {
+			h.html.WriteHTMLErrorPage(w, r, fmt.Errorf("failed to get the graph data: %w", err))
+			return
+		}
+
+		rawData, err := json.Marshal(graphData)
+		if err != nil {
+			h.html.WriteHTMLErrorPage(w, r, fmt.Errorf("failed to encode the graph data: %w", err))
+			return
+		}
+
+		fmt.Fprintf(w, "event: RefreshGraph\ndata: %s\n\n", rawData)
+		w.(http.Flusher).Flush()
+	}
+}
+
+func (h *SysstatsPage) getGraphData(ctx context.Context) (*sysstatstmpl.Graph, error) {
+	stats, err := h.sysstats.GetLast5mn(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get the latest 5mn stats: %w", err)
 	}
 
 	memoryTotal := make([]*float64, len(stats))
@@ -74,13 +133,45 @@ func (h *SysstatsPage) printListPage(w http.ResponseWriter, r *http.Request) {
 		cacheBuffer[i] = ptr.To(stat.Memory().BufCache().GBytes())
 	}
 
-	h.html.WriteHTMLTemplate(w, r, http.StatusOK, &sysstatstmpl.SysstatsPageTmpl{
-		Latest:      stats[len(stats)-1],
-		User:        user,
-		Labels:      labels,
-		MemoryUsed:  memoryUsed,
-		MemoryTotal: memoryTotal,
-		SwapUsed:    swapUsed,
-		CacheBuffer: cacheBuffer,
-	})
+	return &sysstatstmpl.Graph{
+		Type: "line",
+		Data: sysstatstmpl.Data{
+			Labels: labels,
+			Datasets: []sysstatstmpl.Dataset{
+				{
+					Label:       "Total",
+					Data:        memoryTotal,
+					ShowLine:    true,
+					BorderColor: "red",
+					SteppedLine: true,
+					BorderWidth: 1,
+					PointRadius: 0,
+				},
+				{
+					Label:       "RAM",
+					Data:        memoryUsed,
+					ShowLine:    true,
+					BorderColor: "black",
+					BorderWidth: 1,
+					PointRadius: 0,
+				},
+				{
+					Label:       "Cache + Buffer",
+					Data:        cacheBuffer,
+					ShowLine:    true,
+					BorderColor: "blue",
+					BorderWidth: 1,
+					PointRadius: 0,
+				},
+				{
+					Label:       "Swap",
+					Data:        swapUsed,
+					ShowLine:    true,
+					BorderColor: "#bf1b00",
+					BorderWidth: 2,
+					PointRadius: 0,
+				},
+			},
+		},
+	}, nil
 }

--- a/internal/web/html/templates/sysstats/layout.html
+++ b/internal/web/html/templates/sysstats/layout.html
@@ -3,11 +3,17 @@
 
 
 <body hx-ext="response-targets" hx-target-5*="this">
-  {{ yield }}
+  <div id="content">
+    {{ yield }}
+  </div>
 
   <footer></footer>
-  <script src="/assets/js/libs/htmx-2.0.2.min.js"></script>
-  <script src="/assets/js/libs/htmx-response-targets-2.0.0.js"></script>
 </body>
+
+<script src="/assets/js/libs/htmx-2.0.2.min.js"></script>
+<script src="/assets/js/libs/htmx-response-targets-2.0.0.js"></script>
+<script src="/assets/js/libs/htmx-sse-2.2.1.js"></script>
+<div hx-ext="sse" sse-connect="/web/sysstats/sse" hx-swap="none" sse-swap="RefreshGraph"> </div>
+</div>
 
 </html>

--- a/internal/web/html/templates/sysstats/page_list.html
+++ b/internal/web/html/templates/sysstats/page_list.html
@@ -4,99 +4,58 @@
       <p class="mb-0"><strong>Memory</strong></p>
     </div>
     <div class="card-body">
-      <div class="d-flex justify-content-around">
-        <div>
-          <p class="mb-2">RAM</p>
-          <h6>{{.Latest.Memory.UsedMemory.HR}}/{{.Latest.Memory.TotalMemory.HR}}</h6>
-        </div>
-        <div>
-          <p class="mb-2">Cache</p>
-          <h6>{{.Latest.Memory.BufCache.HR}}</h6>
-        </div>
-        <div>
-          <p class="mb-2">Swap</p>
-          <h6>{{.Latest.Memory.UsedSwap.HR}}/{{.Latest.Memory.TotalSwap.HR}}</h6>
-        </div>
-      </div>
+      <canvas id="line-chart"></canvas>
     </div>
-
-    <canvas id="line-chart"></canvas>
   </div>
-</div>
 </div>
 
 
 <script type="module">
   import {Chart, initMDB} from "/assets/js/libs/chart.es.min.js";
 
-  const labels = {{.Labels}}
-  const memoryUsed = {{.MemoryUsed}}
-  const memoryTotal = {{.MemoryTotal}}
-  const swapUsed = {{.SwapUsed}}
-  const cacheBuffer = {{.CacheBuffer}}
-
   initMDB({Chart})
 
-  const dataLine = {
-    type: 'line',
-    data: {
-      labels: labels,
-      datasets: [
-        {
-          label: 'Total',
-          data: memoryTotal,
-          showLine: true,
-          borderColor: 'red',
-          steppedLine: true,
-          borderWidth: 1,
-          pointRadius: 0,
+  const graphData = {{.GraphData}}
+
+  const options = {
+    animation: false,
+    plugins: {
+      legend: {
+        position: 'bottom',
+        labels: {
+          boxWidth: 10,
         },
-        {
-          label: 'RAM',
-          data: memoryUsed,
-          borderColor: 'black',
-          pointRadius: 0,
-        },
-        {
-          label: 'Cache + Buffer',
-          data: cacheBuffer,
-          borderColor: 'blue',
-          // borderWidth: 1,
-          pointRadius: 0,
-        },
-        {
-          label: 'Swap',
-          data: swapUsed,
-          borderColor: '#bf1b00',
-          // borderWidth: 1,
-          pointRadius: 0,
+      },
+    },
+    scales: {
+      y: {
+        ticks: {
+          beginAtZaero: true,
+          callback: function (value, index, values) {
+            return value + " " + "GiB";
+          },
         }
-      ],
+      },
     },
   }
 
-  new Chart(document.getElementById('line-chart'), dataLine, {
-    options: {
-      animation: false,
-      plugins: {
-        legend: {
-          position: 'bottom',
-          labels: {
-            boxWidth: 10,
-          },
-        },
-      },
-      scales: {
-        y: {
-          ticks: {
-            beginAtZaero: true,
-            callback: function (value, index, values) {
-              return value + " " + "GiB";
-            },
-          }
-        },
-      },
-    },
-  });
+
+  console.log(graphData)
+  const chart = document.getElementById('line-chart');
+  const chartInstance = new Chart(chart, graphData, options);
+
+  function refreshGraph(data) {
+    console.log('refresh')
+    console.log(data.data)
+    chartInstance.update(data.data)
+  }
+
+  document.body.addEventListener('htmx:sseMessage', function (e) {
+    if (e.detail.type !== "RefreshGraph") {
+      return
+    }
+
+    refreshGraph(JSON.parse(e.detail.data))
+  })
 
 </script>

--- a/internal/web/html/templates/sysstats/templates.go
+++ b/internal/web/html/templates/sysstats/templates.go
@@ -1,18 +1,27 @@
 package sysstats
 
-import (
-	"github.com/Peltoche/zapette/internal/service/sysstats"
-	"github.com/Peltoche/zapette/internal/service/users"
-)
-
 type SysstatsPageTmpl struct {
-	Latest      sysstats.Stats
-	User        *users.User
-	Labels      []*string
-	MemoryUsed  []*float64
-	MemoryTotal []*float64
-	SwapUsed    []*float64
-	CacheBuffer []*float64
+	GraphData *Graph
 }
 
 func (t *SysstatsPageTmpl) Template() string { return "sysstats/page_list" }
+
+type Dataset struct {
+	Label       string     `json:"label"`
+	Data        []*float64 `json:"data"`
+	ShowLine    bool       `json:"showLine"`
+	BorderColor string     `json:"borderColor"`
+	SteppedLine bool       `json:"steppedLine"`
+	BorderWidth int        `json:"borderWidth"`
+	PointRadius int        `json:"pointRadius"`
+}
+
+type Data struct {
+	Labels   []*string `json:"labels"`
+	Datasets []Dataset `json:"datasets"`
+}
+
+type Graph struct {
+	Type string `json:"type"`
+	Data Data   `json:"data"`
+}

--- a/internal/web/html/writer.go
+++ b/internal/web/html/writer.go
@@ -111,7 +111,7 @@ func NewRenderer(cfg Config) *Renderer {
 func (t *Renderer) writeHTML(w http.ResponseWriter, r *http.Request, status int, template string, args any) {
 	layout := ""
 
-	if strings.Contains(template, "page") {
+	if strings.Contains(template, "page") && r.Header.Get("HX-Boosted") == "" && r.Header.Get("HX-Request") == "" {
 		dir := path.Dir(template)
 
 		for {


### PR DESCRIPTION
This service is now trigger each time the `sysstats` table receive a sql change (insert,update,delete).